### PR TITLE
fix(tocurrency): remove invalid currency string

### DIFF
--- a/src/toCurrency/toCurrency.test.ts
+++ b/src/toCurrency/toCurrency.test.ts
@@ -23,10 +23,6 @@ describe("Util: toCurrency", () => {
         expect(toCurrency("1000.123456", { decimals: 4 })).toEqual("1,000.1235");
     });
 
-    it("Should allow passing a currency string", () => {
-        expect(toCurrency(1000, { currency: "kr" })).toEqual("1,000 kr");
-    });
-
     it("Should return empty string if value passed is not a string or number", () => {
         expect(toCurrency(new Date() as any)).toEqual("");
     });

--- a/src/toCurrency/toCurrency.test.ts
+++ b/src/toCurrency/toCurrency.test.ts
@@ -13,14 +13,14 @@ describe("Util: toCurrency", () => {
         expect(toCurrency("1000.22", { separator: " ", radix: "," })).toEqual("1 000,22");
     });
 
-    it("Should allow hiding cents", () => {
-        expect(toCurrency(1000.22, { noCents: true })).toEqual("1,000");
-        expect(toCurrency("1000.22", { noCents: true })).toEqual("1,000");
+    it("Should allow hiding decimals", () => {
+        expect(toCurrency(1000.22, { showDecimals: true })).toEqual("1,000");
+        expect(toCurrency("1000.22", { showDecimals: true })).toEqual("1,000");
     });
 
     it("Should allow specifying the number of decimal places", () => {
-        expect(toCurrency(1000.123456, { decimals: 4 })).toEqual("1,000.1235");
-        expect(toCurrency("1000.123456", { decimals: 4 })).toEqual("1,000.1235");
+        expect(toCurrency(1000.123456, { numOfDecimals: 4 })).toEqual("1,000.1235");
+        expect(toCurrency("1000.123456", { numOfDecimals: 4 })).toEqual("1,000.1235");
     });
 
     it("Should return empty string if value passed is not a string or number", () => {

--- a/src/toCurrency/toCurrency.ts
+++ b/src/toCurrency/toCurrency.ts
@@ -1,14 +1,14 @@
 export interface ToCurrencyOptions {
     separator?: string;
     radix?: string;
-    noCents?: boolean;
-    decimals?: number;
+    showDecimals?: boolean;
+    numOfDecimals?: number;
 }
 
 /**
  * Formats a number or a string number to a currency format
  * @param {number} value raw number value
- * @param {ToCurrencyOptions} options You can control the sperator, radix string and showing cents using these options
+ * @param {ToCurrencyOptions} options You can control the sperator, radix, decimals visibility and number of decimal places using these options
  * @returns {string} The formatted currency string
  */
 export function toCurrency(value: number | string, options: ToCurrencyOptions = {}): string {
@@ -20,7 +20,7 @@ export function toCurrency(value: number | string, options: ToCurrencyOptions = 
             num = val;
         } else {
             num = Math.floor(val);
-            cents = options && options.noCents ? null : Number((val - Math.floor(val)).toFixed(options && options.decimals ? options.decimals : 2).replace("0.", ""));
+            cents = options && options.showDecimals ? null : Number((val - Math.floor(val)).toFixed(options && options.numOfDecimals ? options.numOfDecimals : 2).replace("0.", ""));
         }
         const list: Array<string> = String(num).split("");
         const newList: Array<string> = [];

--- a/src/toCurrency/toCurrency.ts
+++ b/src/toCurrency/toCurrency.ts
@@ -3,13 +3,12 @@ export interface ToCurrencyOptions {
     radix?: string;
     noCents?: boolean;
     decimals?: number;
-    currency?: string;
 }
 
 /**
  * Formats a number or a string number to a currency format
  * @param {number} value raw number value
- * @param {ToCurrencyOptions} options You can control the sperator, radix, currency string and showing cents using these options
+ * @param {ToCurrencyOptions} options You can control the sperator, radix string and showing cents using these options
  * @returns {string} The formatted currency string
  */
 export function toCurrency(value: number | string, options: ToCurrencyOptions = {}): string {
@@ -34,7 +33,7 @@ export function toCurrency(value: number | string, options: ToCurrencyOptions = 
             }
         });
         amount = newList.join("");
-        return amount + (cents ? `${options && options.radix ? options.radix : "."}${cents}` : "") + (options && options.currency ? ` ${options.currency}` : "");
+        return amount + (cents ? `${options && options.radix ? options.radix : "."}${cents}` : "");
     };
     if (typeof value === "number") {
         return format(value);


### PR DESCRIPTION
the placement of the currency string can vary based on preference and locale. therefore, it is
removed. alternatively, you can just concatenate the currency string with the output of this utility