### PR TITLE
fix(todate): todate returns null when input format is not passed

### DIFF
--- a/src/toDate/toDate.test.ts
+++ b/src/toDate/toDate.test.ts
@@ -22,4 +22,11 @@ describe("Util: toDate", () => {
     it("Should return null when wrong date string is passed", () => {
         expect(toDate("not a date")).toBeNull();
     });
+
+    it("Should convert to date even if inputFormat is not passed", () => {
+        const date: Date = toDate("2020-02-01T00:00:00.000+00:00");
+        expect(date.getFullYear()).toEqual(2020);
+        expect(date.getMonth()).toEqual(1);
+        expect(date.getDate()).toEqual(1);
+    });
 });

--- a/src/toDate/toDate.ts
+++ b/src/toDate/toDate.ts
@@ -8,7 +8,7 @@ import moment, { Moment } from "moment";
  */
 export function toDate(value: string | Date, inputFormat: string = null): Date {
     if (value) {
-        const momentDate: Moment = moment(value, String(inputFormat));
+        const momentDate: Moment = moment(value, inputFormat);
         if (momentDate.isValid()) {
             return momentDate.toDate();
         }


### PR DESCRIPTION
this fixes a bug that returns null when inputformat is not passed