### PR TITLE
fix(formvalidator): remove unnecessary fields param

### DIFF
--- a/src/FormValidator/FormValidator.test.ts
+++ b/src/FormValidator/FormValidator.test.ts
@@ -84,7 +84,7 @@ describe("Form Validator", () => {
         const expectedErrors: ModelErrors<CustomType> = { first: { errorCode: "moreThanMaxValue" } };
         const test: CustomType = { first: 123, second: 100 };
         const validator: FormValidator<CustomType> = new FormValidator<CustomType>(test)
-            .addCustomValidation(["first", "second"], ["first"], (): ModelFieldError => {
+            .addCustomValidation(["first"], (): ModelFieldError => {
                 if (test.first > test.second) {
                     return expectedErrors.first;
                 } else {
@@ -100,7 +100,7 @@ describe("Form Validator", () => {
         const test: CustomType = { first: 123, second: 100 };
         const validator: FormValidator<CustomType> = new FormValidator<CustomType>(test)
             .addValidation(["first"], "valueRange", { minValue: 1000 })
-            .addCustomValidation(["first", "second"], ["first"], (): ModelFieldError => {
+            .addCustomValidation(["first"], (): ModelFieldError => {
                 if (test.first > test.second) {
                     return expectedCustomErrors.first;
                 } else {
@@ -134,7 +134,7 @@ describe("Form Validator", () => {
         testCases.map((testCase: TestCase2) => {
             test(testCase.title, () => {
                 const validator: FormValidator<CustomType> = new FormValidator<CustomType>({ first: 123, second: 100 })
-                    .addCustomValidation(testCase.fields, testCase.fields, () => ({ errorCode: "afterMaxDate" }))
+                    .addCustomValidation(testCase.fields, () => ({ errorCode: "afterMaxDate" }))
                     .validate();
                 expect(validator.getErrors()).toEqual({});
             });

--- a/src/FormValidator/FormValidator.ts
+++ b/src/FormValidator/FormValidator.ts
@@ -40,7 +40,6 @@ export type FormFieldTypes = "date" | "string" | "number" | "array" | "object";
 type SpecialPick<T, K extends keyof T, P extends keyof T> = Required<Pick<T, K>> | Required<Pick<T, P>> | Required<Pick<T, K | P>>;
 
 type CustomValidatorSpec<T> = {
-    fields: Array<keyof T>;
     errorFields: Array<keyof T>;
     validator: (...args: any) => ModelFieldError;
 };
@@ -131,15 +130,14 @@ export class FormValidator<T> {
 
     /**
      * Add a custom validator that returns an error message if found
-     * @param {Array<string>} fields The fields to be validated
      * @param {Array<string>} errorFields The fields where the error is reported to
      * @param {function} validator The validator method
      * @returns {FormValidator} The form validator object
      * @example addValidator(["balance", "payment"], ["payment"], (balance: number, payment: number) => { return payment > balance ? "The payment exceeds your balance" : null; });
      */
-    public addCustomValidation(fields: Array<keyof T>, errorFields: Array<keyof T>, validator: () => ModelFieldError<any>): FormValidator<T> {
-        if (fields && fields instanceof Array && fields.length && errorFields && errorFields instanceof Array && errorFields.length && validator && validator instanceof Function) {
-            this.customValidators.push({ fields, errorFields, validator });
+    public addCustomValidation(errorFields: Array<keyof T>, validator: () => ModelFieldError<any>): FormValidator<T> {
+        if (errorFields && errorFields instanceof Array && errorFields.length && validator && validator instanceof Function) {
+            this.customValidators.push({ errorFields, validator });
         }
         return this;
     }


### PR DESCRIPTION
When creating a custom validator, there is an unnecessary param that is required which is the fields
that the custom validation will touch during its execution. This used to be used since it gets
recycled back to the validator to serve as a snapshot validation. Meaning that running the validate
method will validate the value at the time the validator has been created, any further changes
that happened after will not be included in the validation. This feature has been removed recently, therefore, there is no need for this parameter to exist. Just pass the fields where the error will
appear in and the custom validation method