### PR TITLE
feat(openapi-generator): allow user to disable mock generation

### DIFF
--- a/src/openapiGenerator/openapiGenerator.ts
+++ b/src/openapiGenerator/openapiGenerator.ts
@@ -70,9 +70,10 @@ export function generatorFn() {
                     command += ` ${item.key[0]} ${item.value}`;
                 }
             });
-            const sebTemplatePath: string = CustomTemplates.find(
+            const templateConfig: SEBTemplate = CustomTemplates.find(
                 (item: SEBTemplate) => item.generator === generatorName
-            )?.templatePath;
+            );
+            const sebTemplatePath: string = templateConfig?.templatePath;
             if (
                 !args.openapiTemplate &&
                 (!generateArgs.t && !generateArgs["template-dir"]) &&
@@ -109,8 +110,10 @@ export function generatorFn() {
             if (!args.disableDirClean && existsSync(outputDir)){
                 deleteFolderRecursive(outputDir);
             }
-            // generate mock
-            generateMock((generateArgs.i || generateArgs["input-spec"]), outputDir);
+            if (!args.disableMock && !templateConfig?.disableMock) {
+                // generate mock
+                generateMock((generateArgs.i || generateArgs["input-spec"]), outputDir);
+            }
         }
         CustomOptions.filter(({ option }: CustomOptionType) => !!option).map((item: CustomOptionType) => {
             const customOption: CustomOptionsArgumentType = minimist(item.option);

--- a/src/openapiGenerator/options/customOptions.ts
+++ b/src/openapiGenerator/options/customOptions.ts
@@ -14,6 +14,7 @@ export interface CustomOptionType extends OptionType {
 export interface SEBTemplate {
     generator: OpenApiGenerator;
     templatePath: string;
+    disableMock?: boolean;
 }
 
 export interface CustomOptionsArgumentType {
@@ -21,6 +22,7 @@ export interface CustomOptionsArgumentType {
     u?: string;
     openapiTemplate?: boolean;
     disableDirClean?: boolean;
+    disableMock?: boolean;
     interceptorPath?: string;
     configPath?: string;
 }
@@ -30,6 +32,7 @@ enum OptionName {
     baseUrlShort = "-u",
     openapiTemplate = "--openapiTemplate",
     disableDirClean = "--disableDirClean",
+    disableMock = "--disableMock",
     interceptorPath = "--interceptorPath",
     configPath = "--configPath",
 }
@@ -52,6 +55,11 @@ const options: Array<CustomOptionType> = [
     {
         option: [OptionName.disableDirClean],
         description: "disable direactory clean",
+        noValue: true
+    },
+    {
+        option: [OptionName.disableMock],
+        description: "disable generation of mock.json",
         noValue: true
     },
     {


### PR DESCRIPTION
add in --disableMock option to enable user for preventing mock.json from generating