### PR TITLE
fix(openapi-generator): fixes dates in mock generator

### DIFF
--- a/src/openapiGenerator/mockGenerator/generateData.ts
+++ b/src/openapiGenerator/mockGenerator/generateData.ts
@@ -72,7 +72,7 @@ export function generateData(modelName: string, schema: OpenAPIV2.SchemaObject |
             default:
                 let example: string = schema.example ? schema.example : schema.enum ? schema.enum[0] : modelName;
                 if (schema.format === "date-time") {
-                    example = new Date().toLocaleString();
+                    example = new Date("2020 01 01").toLocaleString();
                 }
                 newModel = example;
         }


### PR DESCRIPTION
fixes the default mock generator to generate a predefined default date instead of current system