### PR TITLE
fix(isphonenumber): fix isphonenumber validation to match 4-15 digits

### DIFF
--- a/src/FormValidator/FormValidator.test.ts
+++ b/src/FormValidator/FormValidator.test.ts
@@ -56,7 +56,8 @@ describe("Form Validator", () => {
             { type: "validEmail", value: "abc@email.com", expected: noError },
             { type: "strongPassword", value: "123", expected: { errorCode: "weakPassword" } },
             { type: "strongPassword", value: "RYGc1tc7C6nyjzz", expected: noError },
-            { type: "isPhoneNumber", value: "5465", expected: { errorCode: "invalidPhoneNumber" } },
+            { type: "isPhoneNumber", value: "546", expected: { errorCode: "invalidPhoneNumber" } },
+            { type: "isPhoneNumber", value: "0123456789123456", expected: { errorCode: "invalidPhoneNumber" } },
             { type: "isPhoneNumber", value: "0123549874", expected: noError },
             // Empty values should not be validated unless required
             { type: "isDate", value: null, expected: noError },

--- a/src/isPhoneNumber/isPhoneNumber.test.ts
+++ b/src/isPhoneNumber/isPhoneNumber.test.ts
@@ -12,7 +12,10 @@ describe("Util: isPhoneNumber", () => {
         { statement: "Should return false for null", params: null, result: false },
         { statement: "Should return false for random string", params: "asbcdasdf", result: false },
         { statement: "Should return true for valid phone", params: "06449561629", result: true },
-        { statement: "Should return true for valid phone", params: "6449561629", result: true },
+        { statement: "Should accept numbers that are 4 digits long", params: "1234", result: true },
+        { statement: "Should not accept numbers less than 4 digits long", params: "123", result: false },
+        { statement: "Should accept numbers that are 15 digits long", params: "012345678912345", result: true },
+        { statement: "Should not accept numbers longer than 15 digits long", params: "0123456789123456", result: false },
     ];
     testCases.map((testCase: TestCase) => {
         it(`${testCase.statement} | params: ${JSON.stringify(testCase.params)} | result: ${testCase.result}`, () => {

--- a/src/isPhoneNumber/isPhoneNumber.ts
+++ b/src/isPhoneNumber/isPhoneNumber.ts
@@ -4,5 +4,5 @@
  * @returns {boolean} true if it is valid
  */
 export function isPhoneNumber(value: string | number): boolean {
-    return new RegExp(/^(0)?([0-9]{7,13})$/g).test(String(value));
+    return new RegExp(/^[0-9]{4,15}$/g).test(String(value));
 }


### PR DESCRIPTION
Following the standard validation rules online, it seems that phone numbers can have a length of
4-15 digits long. This fix address that.